### PR TITLE
Fix require usage in ESM build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Change compilation (remove all `require` in ES build) ([Issue#23])
+- Better detection of unavailable Crypto capacity
+- (dev) Don't allow Testcafe 1.20.* versions
+
+### Changed
+
+- (dev) Use shorthand persist function in test
+
 ## [2.0.0]
 
 ### Added
@@ -108,4 +118,5 @@ First version
 [Issue#19]: https://github.com/MacFJA/svelte-persistent-store/issues/19
 [Issue#20]: https://github.com/MacFJA/svelte-persistent-store/issues/20
 [Issue#21]: https://github.com/MacFJA/svelte-persistent-store/issues/21
+[Issue#23]: https://github.com/MacFJA/svelte-persistent-store/issues/23
 [PR#8]: https://github.com/MacFJA/svelte-persistent-store/pull/8

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "svelte": "^3.42.1",
         "svelte-check": "^2.8.0",
         "svelte-preprocess": "^4.7.4",
-        "testcafe": "^1.18.3",
+        "testcafe": "^1.18.3 <1.20.0",
         "tslib": "^2.3.0",
         "typescript": "^4.7.4"
       },
@@ -2902,12 +2902,6 @@
         "node": "*"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-      "dev": true
-    },
     "node_modules/async-exit-hook": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
@@ -3913,15 +3907,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/email-validator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
-      "dev": true,
-      "engines": {
-        "node": ">4.0"
-      }
-    },
     "node_modules/emittery": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
@@ -4738,18 +4723,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-os-info": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-os-info/-/get-os-info-1.0.2.tgz",
-      "integrity": "sha512-Nlgt85ph6OHZ4XvTcC8LMLDDFUzf7LAinYJZUwzrnc3WiO+vDEHDmNItTtzixBDLv94bZsvJGrrDRAE6uPs4MQ==",
-      "dev": true,
-      "dependencies": {
-        "getos": "^3.2.1",
-        "macos-release": "^3.0.1",
-        "os-family": "^1.1.0",
-        "windows-release": "^5.0.1"
-      }
-    },
     "node_modules/get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -4797,15 +4770,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "dev": true,
-      "dependencies": {
-        "async": "^3.2.0"
       }
     },
     "node_modules/glob": {
@@ -5978,18 +5942,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/macos-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.1.0.tgz",
-      "integrity": "sha512-/M/R0gCDgM+Cv1IuBG1XGdfTFnMEG6PZeT+KGWHO/OG+imqmaD9CH5vHBTycEM3+Kc4uG2Il+tFAuUWLqQOeUA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -6775,28 +6727,6 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "node_modules/prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "dependencies": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/prompts/node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -7435,12 +7365,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -7833,9 +7757,9 @@
       "dev": true
     },
     "node_modules/testcafe": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.20.1.tgz",
-      "integrity": "sha512-D5UQsR10zsqPSqN4uWxS8CjmpaRUSduo3hjQscIzww8/uZ3AmOYJOrIk+punpieCmcwclfGz6ic2pdRv21rNnA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.6.tgz",
+      "integrity": "sha512-5X/Chn5zbHy8TftyB/iXfKOizrYM8vrNLSjjyRQCW2IpYh//7EUJ0MZmBKRcXye9//eLaOoUBs/FDvAW55j4Lw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.1",
@@ -7867,19 +7791,17 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^8.3.0",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
         "device-specs": "^1.0.0",
         "diff": "^4.0.2",
         "elegant-spinner": "^1.0.1",
-        "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
         "execa": "^4.0.3",
-        "get-os-info": "^1.0.2",
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
         "graphlib": "^2.1.5",
@@ -7892,10 +7814,10 @@
         "is-stream": "^2.0.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
-        "log-update-async-hook": "^2.0.7",
+        "log-update-async-hook": "^2.0.6",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
-        "moment": "^2.29.4",
+        "moment": "^2.10.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
         "nanoid": "^3.1.31",
@@ -7906,7 +7828,6 @@
         "pngjs": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "promisify-event": "^1.0.0",
-        "prompts": "^2.4.2",
         "qrcode-terminal": "^0.10.0",
         "read-file-relative": "^1.2.0",
         "replicator": "^1.0.5",
@@ -7917,15 +7838,14 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.7.2",
+        "testcafe-hammerhead": "24.5.18",
         "testcafe-legacy-api": "5.1.4",
-        "testcafe-reporter-dashboard": "1.0.0-rc.3",
+        "testcafe-reporter-dashboard": "0.2.5",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.2.1",
-        "testcafe-safe-storage": "^1.1.1",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.2.2",
@@ -7936,7 +7856,7 @@
         "testcafe": "bin/testcafe-with-v8-flag-filter.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/testcafe-browser-tools": {
@@ -8191,13 +8111,13 @@
       "dev": true
     },
     "node_modules/testcafe-reporter-dashboard": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.3.tgz",
-      "integrity": "sha512-F4gphX9/KlZzEz26I9LwUw7DKdKFQEpsU4Pr04ssBOJCyZh4ST7kuOyB+JMqr4iJfE9zu6+g6aaXumM+ad61JA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.5.tgz",
+      "integrity": "sha512-vbK8XrpbcFAEgnfWJOfqAnlmj/wt5pXXER/OSYI9RzSw+uwu8voLWbKcUAcnjltk0AM4c0wvI0DhjKmops2y2Q==",
       "dev": true,
       "dependencies": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.12.1",
+        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -8256,10 +8176,10 @@
       "integrity": "sha512-ge1msi8RyNVyK0QrsmC79zedV7jHasKpBPeOUZd/ORpbYLeYDnprjIeOuIukw0knnTieeYsOK29/ZD+UI7/tdw==",
       "dev": true
     },
-    "node_modules/testcafe-safe-storage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
-      "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
+    "node_modules/testcafe/node_modules/@types/estree": {
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
       "dev": true
     },
     "node_modules/testcafe/node_modules/@types/node": {
@@ -8318,6 +8238,23 @@
         "node": ">= 12"
       }
     },
+    "node_modules/testcafe/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/testcafe/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -8325,6 +8262,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/esotope-hammerhead": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.1.tgz",
+      "integrity": "sha512-RG4orJ1xy+zD6fTEKuDYaqCuL1ymYa1/Bp+j9c7b/u7B8yI6+Qgg8o4lT1EDAOG9eBzBtwtTWR0chqt3hr0hZw==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.46"
       }
     },
     "node_modules/testcafe/node_modules/has-flag": {
@@ -8357,6 +8303,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/testcafe/node_modules/lru-cache": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
+      "integrity": "sha512-qkisDmHMe8gxKujmC1BdaqgkoFlioLDCUwaFBA3lX8Ilhr3YzsasbGYaiADMjxQnj+aiZUKgGKe/BN3skMwXWw==",
+      "dev": true
+    },
+    "node_modules/testcafe/node_modules/merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^2.0.1"
+      }
+    },
     "node_modules/testcafe/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -8376,6 +8337,62 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead": {
+      "version": "24.5.18",
+      "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.18.tgz",
+      "integrity": "sha512-ae7ikqW4SzKY81BDaCc5eVyTmiiqbq8qGpr484GyVobRb4stPUKCDVyYm05t7BiO60Lhhh9Fm0w5o3oNHqQxQg==",
+      "dev": true,
+      "dependencies": {
+        "acorn-hammerhead": "0.6.1",
+        "asar": "^2.0.1",
+        "bowser": "1.6.0",
+        "crypto-md5": "^1.0.0",
+        "css": "2.2.3",
+        "debug": "4.3.1",
+        "esotope-hammerhead": "0.6.1",
+        "http-cache-semantics": "^4.1.0",
+        "iconv-lite": "0.5.1",
+        "lodash": "^4.17.20",
+        "lru-cache": "2.6.3",
+        "match-url-wildcard": "0.0.4",
+        "merge-stream": "^1.0.1",
+        "mime": "~1.4.1",
+        "mustache": "^2.1.1",
+        "nanoid": "^3.1.12",
+        "os-family": "^1.0.0",
+        "parse5": "2.2.3",
+        "pinkie": "2.0.4",
+        "read-file-relative": "^1.2.0",
+        "semver": "5.5.0",
+        "tough-cookie": "4.0.0",
+        "tunnel-agent": "0.6.0",
+        "webauth": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/bowser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+      "integrity": "sha512-Fk23J0+vRnI2eKDEDoUZXWtbMjijr098lKhuj4DKAfMKMCRVfJOuxXlbpxy0sTgbZ/Nr2N8MexmOir+GGI/ZMA==",
+      "dev": true
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/parse5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "integrity": "sha512-yJQdbcT+hCt6HD+BuuUvjHUdNwerQIKSJSm7tXjtp6oIH5Mxbzlt/VIIeWxblsgcDt1+E7kxPeilD5McWswStA==",
+      "dev": true
+    },
+    "node_modules/testcafe/node_modules/testcafe-hammerhead/node_modules/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/testcafe/node_modules/typescript": {
@@ -8927,65 +8944,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/windows-release": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-5.0.1.tgz",
-      "integrity": "sha512-y1xFdFvdMiDXI3xiOhMbJwt1Y7dUxidha0CWPs1NgjZIjZANTcX7+7bMqNjuezhzb8s5JGEiBAbQjQQYYy7ulw==",
-      "dev": true,
-      "dependencies": {
-        "execa": "^5.1.1"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/windows-release/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/windows-release/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.17.0"
       }
     },
     "node_modules/word-wrap": {
@@ -11101,12 +11059,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
-      "dev": true
-    },
     "async-exit-hook": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-1.1.2.tgz",
@@ -11877,12 +11829,6 @@
       "integrity": "sha512-B+ZM+RXvRqQaAmkMlO/oSe5nMUOaUnyfGYCEHoR8wrXsZR2mA0XVibsxV1bvTwxdRWah1PkQqso2EzhILGHtEQ==",
       "dev": true
     },
-    "email-validator": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/email-validator/-/email-validator-2.0.4.tgz",
-      "integrity": "sha512-gYCwo7kh5S3IDyZPLZf6hSS0MnZT8QmJFqYvbqlDZSbwdZlY6QZWxJ4i/6UhITOJ4XzyI647Bm2MXKCLqnJ4nQ==",
-      "dev": true
-    },
     "emittery": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
@@ -12544,18 +12490,6 @@
         "has-symbols": "^1.0.3"
       }
     },
-    "get-os-info": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-os-info/-/get-os-info-1.0.2.tgz",
-      "integrity": "sha512-Nlgt85ph6OHZ4XvTcC8LMLDDFUzf7LAinYJZUwzrnc3WiO+vDEHDmNItTtzixBDLv94bZsvJGrrDRAE6uPs4MQ==",
-      "dev": true,
-      "requires": {
-        "getos": "^3.2.1",
-        "macos-release": "^3.0.1",
-        "os-family": "^1.1.0",
-        "windows-release": "^5.0.1"
-      }
-    },
     "get-port": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
@@ -12585,15 +12519,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
-      }
-    },
-    "getos": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-3.2.1.tgz",
-      "integrity": "sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==",
-      "dev": true,
-      "requires": {
-        "async": "^3.2.0"
       }
     },
     "glob": {
@@ -13485,12 +13410,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "macos-release": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.1.0.tgz",
-      "integrity": "sha512-/M/R0gCDgM+Cv1IuBG1XGdfTFnMEG6PZeT+KGWHO/OG+imqmaD9CH5vHBTycEM3+Kc4uG2Il+tFAuUWLqQOeUA==",
-      "dev": true
-    },
     "magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -14052,24 +13971,6 @@
         "pinkie-promise": "^2.0.0"
       }
     },
-    "prompts": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
-      "dev": true,
-      "requires": {
-        "kleur": "^3.0.3",
-        "sisteransi": "^1.0.5"
-      },
-      "dependencies": {
-        "kleur": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-          "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-          "dev": true
-        }
-      }
-    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -14553,12 +14454,6 @@
         "tinydate": "^1.0.0"
       }
     },
-    "sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
-    },
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14827,9 +14722,9 @@
       }
     },
     "testcafe": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.20.1.tgz",
-      "integrity": "sha512-D5UQsR10zsqPSqN4uWxS8CjmpaRUSduo3hjQscIzww8/uZ3AmOYJOrIk+punpieCmcwclfGz6ic2pdRv21rNnA==",
+      "version": "1.18.6",
+      "resolved": "https://registry.npmjs.org/testcafe/-/testcafe-1.18.6.tgz",
+      "integrity": "sha512-5X/Chn5zbHy8TftyB/iXfKOizrYM8vrNLSjjyRQCW2IpYh//7EUJ0MZmBKRcXye9//eLaOoUBs/FDvAW55j4Lw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.1",
@@ -14861,19 +14756,17 @@
         "chalk": "^2.3.0",
         "chrome-remote-interface": "^0.30.0",
         "coffeescript": "^2.3.1",
-        "commander": "^8.3.0",
+        "commander": "^8.0.0",
         "debug": "^4.3.1",
         "dedent": "^0.4.0",
         "del": "^3.0.0",
         "device-specs": "^1.0.0",
         "diff": "^4.0.2",
         "elegant-spinner": "^1.0.1",
-        "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
         "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^1.3.6",
         "execa": "^4.0.3",
-        "get-os-info": "^1.0.2",
         "globby": "^11.0.4",
         "graceful-fs": "^4.1.11",
         "graphlib": "^2.1.5",
@@ -14886,10 +14779,10 @@
         "is-stream": "^2.0.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.13",
-        "log-update-async-hook": "^2.0.7",
+        "log-update-async-hook": "^2.0.6",
         "make-dir": "^3.0.0",
         "mime-db": "^1.41.0",
-        "moment": "^2.29.4",
+        "moment": "^2.10.3",
         "moment-duration-format-commonjs": "^1.0.0",
         "mustache": "^2.1.2",
         "nanoid": "^3.1.31",
@@ -14900,7 +14793,6 @@
         "pngjs": "^3.3.1",
         "pretty-hrtime": "^1.0.3",
         "promisify-event": "^1.0.0",
-        "prompts": "^2.4.2",
         "qrcode-terminal": "^0.10.0",
         "read-file-relative": "^1.2.0",
         "replicator": "^1.0.5",
@@ -14911,15 +14803,14 @@
         "source-map-support": "^0.5.16",
         "strip-bom": "^2.0.0",
         "testcafe-browser-tools": "2.0.23",
-        "testcafe-hammerhead": "24.7.2",
+        "testcafe-hammerhead": "24.5.18",
         "testcafe-legacy-api": "5.1.4",
-        "testcafe-reporter-dashboard": "1.0.0-rc.3",
+        "testcafe-reporter-dashboard": "0.2.5",
         "testcafe-reporter-json": "^2.1.0",
         "testcafe-reporter-list": "^2.1.0",
         "testcafe-reporter-minimal": "^2.1.0",
         "testcafe-reporter-spec": "^2.1.1",
         "testcafe-reporter-xunit": "^2.2.1",
-        "testcafe-safe-storage": "^1.1.1",
         "time-limit-promise": "^1.0.2",
         "tmp": "0.0.28",
         "tree-kill": "^1.2.2",
@@ -14927,6 +14818,12 @@
         "unquote": "^1.1.1"
       },
       "dependencies": {
+        "@types/estree": {
+          "version": "0.0.46",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+          "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==",
+          "dev": true
+        },
         "@types/node": {
           "version": "12.20.55",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
@@ -14974,11 +14871,29 @@
           "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
           "dev": true
         },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
           "dev": true
+        },
+        "esotope-hammerhead": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/esotope-hammerhead/-/esotope-hammerhead-0.6.1.tgz",
+          "integrity": "sha512-RG4orJ1xy+zD6fTEKuDYaqCuL1ymYa1/Bp+j9c7b/u7B8yI6+Qgg8o4lT1EDAOG9eBzBtwtTWR0chqt3hr0hZw==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.46"
+          }
         },
         "has-flag": {
           "version": "3.0.0",
@@ -15001,6 +14916,21 @@
             "is-extglob": "^1.0.0"
           }
         },
+        "lru-cache": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.3.tgz",
+          "integrity": "sha512-qkisDmHMe8gxKujmC1BdaqgkoFlioLDCUwaFBA3lX8Ilhr3YzsasbGYaiADMjxQnj+aiZUKgGKe/BN3skMwXWw==",
+          "dev": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+          "integrity": "sha512-e6RM36aegd4f+r8BZCcYXlO2P3H6xbUM6ktL2Xmf45GAOit9bI4z6/3VU7JwllVO1L7u0UDSg/EhzQ5lmMLolA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -15014,6 +14944,58 @@
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
+          }
+        },
+        "testcafe-hammerhead": {
+          "version": "24.5.18",
+          "resolved": "https://registry.npmjs.org/testcafe-hammerhead/-/testcafe-hammerhead-24.5.18.tgz",
+          "integrity": "sha512-ae7ikqW4SzKY81BDaCc5eVyTmiiqbq8qGpr484GyVobRb4stPUKCDVyYm05t7BiO60Lhhh9Fm0w5o3oNHqQxQg==",
+          "dev": true,
+          "requires": {
+            "acorn-hammerhead": "0.6.1",
+            "asar": "^2.0.1",
+            "bowser": "1.6.0",
+            "crypto-md5": "^1.0.0",
+            "css": "2.2.3",
+            "debug": "4.3.1",
+            "esotope-hammerhead": "0.6.1",
+            "http-cache-semantics": "^4.1.0",
+            "iconv-lite": "0.5.1",
+            "lodash": "^4.17.20",
+            "lru-cache": "2.6.3",
+            "match-url-wildcard": "0.0.4",
+            "merge-stream": "^1.0.1",
+            "mime": "~1.4.1",
+            "mustache": "^2.1.1",
+            "nanoid": "^3.1.12",
+            "os-family": "^1.0.0",
+            "parse5": "2.2.3",
+            "pinkie": "2.0.4",
+            "read-file-relative": "^1.2.0",
+            "semver": "5.5.0",
+            "tough-cookie": "4.0.0",
+            "tunnel-agent": "0.6.0",
+            "webauth": "^1.1.0"
+          },
+          "dependencies": {
+            "bowser": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.6.0.tgz",
+              "integrity": "sha512-Fk23J0+vRnI2eKDEDoUZXWtbMjijr098lKhuj4DKAfMKMCRVfJOuxXlbpxy0sTgbZ/Nr2N8MexmOir+GGI/ZMA==",
+              "dev": true
+            },
+            "parse5": {
+              "version": "2.2.3",
+              "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+              "integrity": "sha512-yJQdbcT+hCt6HD+BuuUvjHUdNwerQIKSJSm7tXjtp6oIH5Mxbzlt/VIIeWxblsgcDt1+E7kxPeilD5McWswStA==",
+              "dev": true
+            },
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
+            }
           }
         },
         "typescript": {
@@ -15247,13 +15229,13 @@
       }
     },
     "testcafe-reporter-dashboard": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-1.0.0-rc.3.tgz",
-      "integrity": "sha512-F4gphX9/KlZzEz26I9LwUw7DKdKFQEpsU4Pr04ssBOJCyZh4ST7kuOyB+JMqr4iJfE9zu6+g6aaXumM+ad61JA==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/testcafe-reporter-dashboard/-/testcafe-reporter-dashboard-0.2.5.tgz",
+      "integrity": "sha512-vbK8XrpbcFAEgnfWJOfqAnlmj/wt5pXXER/OSYI9RzSw+uwu8voLWbKcUAcnjltk0AM4c0wvI0DhjKmops2y2Q==",
       "dev": true,
       "requires": {
         "es6-promise": "^4.2.8",
-        "fp-ts": "^2.12.1",
+        "fp-ts": "^2.9.5",
         "io-ts": "^2.2.14",
         "io-ts-types": "^0.5.15",
         "isomorphic-fetch": "^3.0.0",
@@ -15306,12 +15288,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/testcafe-reporter-xunit/-/testcafe-reporter-xunit-2.2.1.tgz",
       "integrity": "sha512-ge1msi8RyNVyK0QrsmC79zedV7jHasKpBPeOUZd/ORpbYLeYDnprjIeOuIukw0knnTieeYsOK29/ZD+UI7/tdw==",
-      "dev": true
-    },
-    "testcafe-safe-storage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/testcafe-safe-storage/-/testcafe-safe-storage-1.1.2.tgz",
-      "integrity": "sha512-6km7D26+KCQGeFlSQ9fVEU7tD8qdioSpqzxU8CCZkd2KzBS0jTFkqaJ54rPaLdd5+wdhgO3+as3LMm4F0EDeYA==",
       "dev": true
     },
     "text-table": {
@@ -15729,46 +15705,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        }
-      }
-    },
-    "windows-release": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-5.0.1.tgz",
-      "integrity": "sha512-y1xFdFvdMiDXI3xiOhMbJwt1Y7dUxidha0CWPs1NgjZIjZANTcX7+7bMqNjuezhzb8s5JGEiBAbQjQQYYy7ulw==",
-      "dev": true,
-      "requires": {
-        "execa": "^5.1.1"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-          "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.3",
-            "get-stream": "^6.0.0",
-            "human-signals": "^2.1.0",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.1",
-            "onetime": "^5.1.2",
-            "signal-exit": "^3.0.3",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-          "dev": true
-        },
-        "human-signals": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-          "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "svelte": "^3.42.1",
     "svelte-check": "^2.8.0",
     "svelte-preprocess": "^4.7.4",
-    "testcafe": "^1.18.3",
+    "testcafe": "^1.18.3 <1.20.0",
     "tslib": "^2.3.0",
     "typescript": "^4.7.4"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,12 +10,9 @@ const name = pkg.name
     .replace(/^\w/, m => m.toUpperCase())
     .replace(/-\w/g, m => m[1].toUpperCase())
 
-export default {
+const config = (es) => ({
     input: "src/index.ts",
-    output: [
-        { file: pkg.module, "format": "es" },
-        { file: pkg.main, "format": "umd", name }
-    ],
+    output: { file: es ? pkg.module : pkg.main, "format": es ? "es" : "umd", name },
     plugins: [
         sucrase({
             exclude: ["dist/*"],
@@ -23,11 +20,16 @@ export default {
             transforms: ["typescript"]
         }),
         commonjs({
-            ignore: ["crypto", "util"]
+            ignore: es ? [] : ["crypto", "util"]
         }),
         resolve({
             extensions: [".mjs", ".js", ".json", ".node", ".ts"]
         }),
         terser()
     ]
-}
+})
+
+export default [
+    config(true),
+    config(false)
+]

--- a/rollup.test.config.js
+++ b/rollup.test.config.js
@@ -16,12 +16,11 @@ export default {
         sucrase({
             exclude: ["dist/*"],
             include: ["src/*"],
-            transforms: ["typescript"],
-            disableESTransforms: true
+            transforms: ["typescript"]
         }),
         commonjs({ignore: ["crypto", "util"]}),
         resolve({
-            extensions: [".mjs", ".js", ".json", ".node", ".ts"]
+            extensions: [".mjs", ".js", ".json", ".node", ".ts", ".cjs"]
         })
     ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,7 +331,12 @@ export function createIndexedDBStorage<T>(): SelfUpdateStorageInterface<T> {
  * @param encryptionKey The encryption key to use on key and data
  */
 export function createEncryptedStorage<T>(wrapped: StorageInterface<T>, encryptionKey: string): StorageInterface<T>|SelfUpdateStorageInterface<T> {
-    if (typeof window === "undefined" || typeof window?.crypto !== "object" || typeof window?.crypto?.subtle !== "object") {
+    try {
+        if (typeof window !== "undefined" && (typeof window?.crypto !== "object" || typeof window?.crypto?.subtle !== "object")) {
+            throw new Error("Error with Browser WebCrypto lib")
+        }
+        Cyrup.randomBytes(2)
+    } catch (e) {
         switch (noEncryptionMode) {
         case NO_ENCRYPTION_BEHAVIOR.NO_STORAGE:
             warnUser("Unable to find the encryption library. No data will be persisted.")
@@ -343,7 +348,6 @@ export function createEncryptedStorage<T>(wrapped: StorageInterface<T>, encrypti
         default:
             throw new Error("Unable to find the encryption library.")
         }
-
     }
     const listeners: Array<{key: string, listener: (newValue: T) => void}> = []
     const listenerFunction = (eventKey: string, newValue: T) => {

--- a/tests/e2e.ts
+++ b/tests/e2e.ts
@@ -36,7 +36,6 @@ test("Initial state", async t => {
     await t
         .click(clearButton)
         .click(reloadButton)
-        .wait(10)
         .expect(cookieInput.value).eql("John")
         .expect(localInput.value).eql("Foo")
         .expect(sessionInput.value).eql("Bar")

--- a/tests/src/App.svelte
+++ b/tests/src/App.svelte
@@ -1,9 +1,9 @@
 <script>
     import {
         persist,
-        createCookieStorage,
-        createLocalStorage,
-        createSessionStorage,
+        persistCookie,
+        persistBrowserSession,
+        persistBrowserLocal,
         createIndexedDBStorage,
         addSerializableClass,
     } from "../../src/index"
@@ -24,19 +24,19 @@
 
     addSerializableClass(NameHolder)
 
-    let cookieExample = persist(writable('John'), createCookieStorage(), 'sps-userName')
-    let localExample = persist(writable('Foo'), createLocalStorage(), 'sps-action')
-    let sessionExample = persist(writable('Bar'), createSessionStorage(), 'sps-call')
+    let cookieExample = persistCookie(writable('John'), 'sps-userName')
+    let localExample = persistBrowserLocal(writable('Foo'), 'sps-action')
+    let sessionExample = persistBrowserSession(writable('Bar'), 'sps-call')
     let indexedDBExample = persist(writable('Hello'), createIndexedDBStorage(), 'sps-data')
-    let undefinedExample = persist(writable(), createSessionStorage(), 'sps-undefined')
+    let undefinedExample = persistBrowserSession(writable(), 'sps-undefined')
     let undefinedExample2 = persist(writable(), createIndexedDBStorage(), 'sps-undefined')
-    let undefinedExample3 = persist(writable(), createCookieStorage(), 'sps-undefined')
-    let nullExample = persist(writable(null), createSessionStorage(), 'sps-null')
+    let undefinedExample3 = persistCookie(writable(), 'sps-undefined')
+    let nullExample = persistBrowserSession(writable(null), 'sps-null')
     let nullExample2 = persist(writable(null), createIndexedDBStorage(), 'sps-null')
-    let nullExample3 = persist(writable(null), createCookieStorage(), 'sps-null')
-    let classExample = persist(writable(new NameHolder()), createLocalStorage(), 'sps-class')
-    let arrayExample = persist(writable([1,2,3]), createLocalStorage(), 'sps-array')
-    let objectExample = persist(writable({a: 1, b: 2}), createLocalStorage(), 'sps-object')
+    let nullExample3 = persistCookie(writable(null), 'sps-null')
+    let classExample = persistBrowserLocal(writable(new NameHolder()), 'sps-class')
+    let arrayExample = persistBrowserLocal(writable([1,2,3]), 'sps-array')
+    let objectExample = persistBrowserLocal(writable({a: 1, b: 2}), 'sps-object')
 
     let cookie = ''
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,6 @@
   "include": ["src/*"],
   "exclude": ["docs/*", "dist/*"],
   "compilerOptions": {
-    "paths": {
-      "class-hydrator": ["./node_modules/class-hydrator/src/index.ts"]
-    },
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationDir": "types",


### PR DESCRIPTION
Fix #23 

### Fixed

- Change compilation (remove all `require` in ES build) (#23)
- Better detection of unavailable Crypto capacity
- (dev) Don't allow Testcafe 1.20.* versions

### Changed

- (dev) Use shorthand persist function in test
