### PR TITLE
GCMEncryption being incorrectly exported as a type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,5 +14,5 @@ export {
   setSerialization,
 } from "./core"
 export type { CHROME_STORAGE_TYPE, PersistentStore, StorageInterface, SelfUpdateStorageInterface } from "./core"
-export { createEncryptionStorage, createEncryptedStorage, noEncryptionBehavior } from "./encryption"
-export type { NO_ENCRYPTION_BEHAVIOR, Encryption, GCMEncryption } from "./encryption"
+export { createEncryptionStorage, createEncryptedStorage, noEncryptionBehavior, GCMEncryption } from "./encryption"
+export type { NO_ENCRYPTION_BEHAVIOR, Encryption } from "./encryption"


### PR DESCRIPTION
I've moved the GCMEncryption export as it is being exported as a type rather than the implementation 