### PR TITLE
add optional chaining in response to sentry logs

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -153,7 +153,7 @@ export interface SelfUpdateStorageInterface<T> extends StorageInterface<T> {
  * @param {string} key The name of the data key
  */
 export function persist<T>(store: Writable<T>, storage: StorageInterface<T>, key: string): PersistentStore<T> {
-  const initialValue = storage.getValue(key)
+  const initialValue = storage?.getValue(key)
 
   if (null !== initialValue) {
     store.set(initialValue)
@@ -240,14 +240,14 @@ function getBrowserStorage(browserStorage: Storage, listenExternalChanges = fals
     addListener,
     removeListener,
     getValue(key: string): any | null {
-      const value = browserStorage.getItem(key)
+      const value = browserStorage?.getItem(key)
       return deserialize(value)
     },
     deleteValue(key: string) {
-      browserStorage.removeItem(key)
+      browserStorage?.removeItem(key)
     },
     setValue(key: string, value: any) {
-      browserStorage.setItem(key, serialize(value))
+      browserStorage?.setItem(key, serialize(value))
     },
   }
 }


### PR DESCRIPTION
Time to time there are errors in sentry: 
```
Cannot read properties of null (reading 'getItem')
```

<img width="509" alt="{0D3109ED-CF45-48B6-ADE9-A2DAA6C0B479}" src="https://github.com/user-attachments/assets/2f755600-3a47-41d7-8aa1-2993277c7d4e">
