### PR TITLE
Re-export CHROME_STORAGE_TYPE as value instead of type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
   sessionWritable,
   cookieWritable,
 } from "./alias"
-export type { CHROME_STORAGE_TYPE, PersistentStore, StorageInterface, SelfUpdateStorageInterface } from "./core"
+export { CHROME_STORAGE_TYPE } from "./core"
+export type { PersistentStore, StorageInterface, SelfUpdateStorageInterface } from "./core"
 export { createEncryptionStorage, createEncryptedStorage, noEncryptionBehavior, GCMEncryption } from "./encryption"
 export type { NO_ENCRYPTION_BEHAVIOR, Encryption } from "./encryption"


### PR DESCRIPTION
Hi! I've been using your library since 2024, it's very nice! 

Today I went to build a small web extension with it (targeting Firefox primarily, where `chrome` is supported but it has also been redefined under the generic `browser` API) and couldn't import CHROME_STORAGE_TYPE as a value to use it like in the docs example because the enum was exported as a type. This fixes that.

Thank you for sharing the code!