### PR TITLE
Correct legacy import `assert` syntax

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,7 +3,8 @@ import resolve from "@rollup/plugin-node-resolve"
 import sucrase from "@rollup/plugin-sucrase"
 import terser from "@rollup/plugin-terser"
 
-import packageJson from "./package.json" assert {type: "json"}
+import packageJson from "./package.json" with {type: "json"}
+
 
 const name = packageJson.name
   .replaceAll(/^(@\S+\/)?(svelte-)?(\S+)/g, "$3")


### PR DESCRIPTION
(node:2417313) V8: file:///home/ckie/git/svelte-persistent-store/rollup.config.mjs:6 'assert' is deprecated in import statements and support will be removed in a future version; use 'with' instead

Allows use of my usual Node.js v24, previously only worked when i tested on v20.