### PR TITLE
package.json: Switch to prepublish non-only to allow usage as Git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "test": "testcafe all tests/e2e.ts --app 'npx sirv tests --port 5000 --host 0.0.0.0'",
         "prebuild": "tsc",
         "build": "rollup -c",
-        "prepublishOnly": "npm run build"
+        "prepublish": "npm run build"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
npm, pnpm and Yarn all don't run `prepublishOnly` when preparing a Git dependency[1]

There is no commit history indicating why it was `prepublishOnly` nor was it ever changed to this from something else.

[1] https://github.com/pnpm/pnpm/blob/337a110dbc4c569d523a1faf58b540be8f857297/exec/prepare-package/src/index.ts#L13